### PR TITLE
Add methods for historical block processing

### DIFF
--- a/environments/local.toml
+++ b/environments/local.toml
@@ -27,6 +27,11 @@
   # Boolean to filter logs by topics.
   filterLogsByTopics = true
 
+  # Boolean to switch between modes of processing events when starting the server.
+  # Setting to true will fetch filtered events and required blocks in a range of blocks and then process them
+  # Setting to false will fetch blocks consecutively with its events and then process them (Behaviour is followed in realtime processing near head)
+  useBlockRanges = true
+
   # Max block range for which to return events in eventsInRange GQL query.
   # Use -1 for skipping check on block range.
   maxEventsBlockRange = 1000

--- a/environments/local.toml
+++ b/environments/local.toml
@@ -25,7 +25,7 @@
   filterLogsByAddresses = false
 
   # Boolean to filter logs by topics.
-  filterLogsByTopics = false
+  filterLogsByTopics = true
 
   # Max block range for which to return events in eventsInRange GQL query.
   # Use -1 for skipping check on block range.
@@ -81,5 +81,5 @@
   eventsInBatch = 50
   subgraphEventsOrder = true
   blockDelayInMilliSecs = 2000
-  prefetchBlocksInMem = true
+  prefetchBlocksInMem = false
   prefetchBlockCount = 10

--- a/src/database.ts
+++ b/src/database.ts
@@ -247,12 +247,6 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getBlocksAtHeight(repo, height, isPruned);
   }
 
-  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
-    const repo = this._conn.getRepository(BlockProgress);
-
-    return this._baseDatabase.getLatestProcessedBlockProgress(repo, isPruned);
-  }
-
   async markBlocksAsPruned (queryRunner: QueryRunner, blocks: BlockProgress[]): Promise<void> {
     const repo = queryRunner.manager.getRepository(BlockProgress);
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -223,6 +223,12 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.updateSyncStatusChainHead(repo, blockHash, blockNumber, force);
   }
 
+  async forceUpdateSyncStatus (queryRunner: QueryRunner, blockHash: string, blockNumber: number): Promise<SyncStatus> {
+    const repo = queryRunner.manager.getRepository(SyncStatus);
+
+    return this._baseDatabase.forceUpdateSyncStatus(repo, blockHash, blockNumber);
+  }
+
   async getSyncStatus (queryRunner: QueryRunner): Promise<SyncStatus | undefined> {
     const repo = queryRunner.manager.getRepository(SyncStatus);
 
@@ -239,6 +245,12 @@ export class Database implements DatabaseInterface {
     const repo = this._conn.getRepository(BlockProgress);
 
     return this._baseDatabase.getBlocksAtHeight(repo, height, isPruned);
+  }
+
+  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
+    const repo = this._conn.getRepository(BlockProgress);
+
+    return this._baseDatabase.getLatestProcessedBlockProgress(repo, isPruned);
   }
 
   async markBlocksAsPruned (queryRunner: QueryRunner, blocks: BlockProgress[]): Promise<void> {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -513,6 +513,10 @@ export class Indexer implements IndexerInterface {
     return syncStatus;
   }
 
+  async forceUpdateSyncStatus (blockHash: string, blockNumber: number): Promise<SyncStatus> {
+    return this._baseIndexer.forceUpdateSyncStatus(blockHash, blockNumber);
+  }
+
   async getEvent (id: string): Promise<Event | undefined> {
     return this._baseIndexer.getEvent(id);
   }
@@ -527,6 +531,10 @@ export class Indexer implements IndexerInterface {
 
   async getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgress[]> {
     return this._baseIndexer.getBlocksAtHeight(height, isPruned);
+  }
+
+  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
+    return this._db.getLatestProcessedBlockProgress(isPruned);
   }
 
   async fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgress>[]): Promise<{ blockProgress: BlockProgress, events: DeepPartial<Event>[] }[]> {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -533,10 +533,6 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getBlocksAtHeight(height, isPruned);
   }
 
-  async getLatestProcessedBlockProgress (isPruned: boolean): Promise<BlockProgress | undefined> {
-    return this._db.getLatestProcessedBlockProgress(isPruned);
-  }
-
   async fetchEventsAndSaveBlocks (blocks: DeepPartial<BlockProgress>[]): Promise<{ blockProgress: BlockProgress, events: DeepPartial<Event>[] }[]> {
     return this._baseIndexer.fetchEventsAndSaveBlocks(blocks, this._eventSignaturesMap, this.parseEventNameAndArgs.bind(this));
   }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -541,6 +541,10 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.fetchEventsAndSaveBlocks(blocks, this._eventSignaturesMap, this.parseEventNameAndArgs.bind(this));
   }
 
+  async fetchAndSaveFilteredEventsAndBlocks (startBlock: number, endBlock: number): Promise<{ blockProgress: BlockProgress, events: DeepPartial<Event>[] }[]> {
+    return this._baseIndexer.fetchAndSaveFilteredEventsAndBlocks(startBlock, endBlock, this._eventSignaturesMap, this.parseEventNameAndArgs.bind(this));
+  }
+
   async saveBlockAndFetchEvents (block: DeepPartial<BlockProgress>): Promise<[BlockProgress, DeepPartial<Event>[]]> {
     return this._saveBlockAndFetchEvents(block);
   }

--- a/src/job-runner.ts
+++ b/src/job-runner.ts
@@ -30,6 +30,7 @@ export const main = async (): Promise<any> => {
 
   await jobRunnerCmd.exec(async (jobRunner: JobRunner): Promise<void> => {
     await jobRunner.subscribeBlockProcessingQueue();
+    await jobRunner.subscribeHistoricalProcessingQueue();
     await jobRunner.subscribeEventProcessingQueue();
     await jobRunner.subscribeBlockCheckpointQueue();
     await jobRunner.subscribeHooksQueue();


### PR DESCRIPTION
Part of [Block processing optimizations](https://www.notion.so/Block-processing-optimizations-e34d17072f3944ed9a66aab811b4c289)

- Add database and indexer methods required for historical block processing
- Subscribe to historical block processing job queue in job-runner
- Set `useBlockRanges` flag to true for running historical processing